### PR TITLE
Add sendbird-chat-sample-ios to the Open source projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A community-driven collection of Tuist related blog posts, tasks, projects, and 
 - [Katana: Swift apps in a swoosh](https://github.com/BendingSpoons/katana-swift)
 - [Tempura: a holistic approach to iOS development](https://github.com/BendingSpoons/tempura-swift)
 - [Pokedex](https://github.com/ronanociosoig/tuist-pokedex)
+- [Sendbird Chat SDK Sample for iOS](https://github.com/sendbird/sendbird-chat-sample-ios)
 
 ## Blog posts
 


### PR DESCRIPTION
Hello! My team created sample apps by SDK feature level. 

Before using tuist, it was difficult to extend the app scheme because the basic app had to be cloned and the project renamed. After introducing tuist, it is much easier to work.
In addition, I am using github action, and it is very helpful for collaboration because it is easy to check that all apps could build normally.

I think our repo would be a good use case, so I'd like to list it on awesome-tuist.
https://github.com/sendbird/sendbird-chat-sample-ios