### PR TITLE
Add Cloak and SwiftHooks Tuist plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ A community-driven collection of Tuist related blog posts, tasks, projects, and 
 ## Tools
 
 - [asdf-tuist](https://github.com/cprecioso/asdf-tuist)
+- [Cloak: Encrypt and obfuscate secrets for Swift apps](https://github.com/lordcodes/cloak-swift)
+- [SwiftHooks: Share Git hooks between contributors](https://github.com/lordcodes/swifthooks)
 
 ## Blog posts
 


### PR DESCRIPTION
I created a couple of Tuist plugins.

[Cloak](https://github.com/lordcodes/cloak-swift) to encrypt and obfuscate secrets, then pass them into Swift applications. For example, to have secrets you need to build into an iOS app without having them purely in plaintext within resources or source code.

[SwiftHooks](https://github.com/lordcodes/swifthooks) to share Git hooks between project contributors, installing them using Tuist.