### PR TITLE
XCFolder – Converts Xcode virtual groups into actual directories, enabling seamless integration with Tuist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A community-driven collection of Tuist related blog posts, tasks, projects, and 
 
 - [asdf-tuist](https://github.com/cprecioso/asdf-tuist)
 - [TuistAutoGen](https://github.com/naldal/TuistAutoGen)
+- [XCFolder](https://github.com/ZhgChgLi/XCFolder)
 
 ## Plugins
 


### PR DESCRIPTION
https://github.com/ZhgChgLi/XCFolder