### PR TITLE
Add Back Market's Tuist blog post series (Parts I-III)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ A community-driven collection of Tuist related blog posts, tasks, projects, and 
 ## Blog posts
 
 - [Real-World Xcode Project Using Tuist](https://getstream.io/blog/real-world-xcode-tuist/)
+- [Back Market x Tuist - Part I: Why We Moved Our iOS Project To Tuist](https://engineering.backmarket.com/back-market-x-tuist-part-i-why-we-moved-our-ios-project-to-tuist-f161cf914700)
+- [Back Market x Tuist II: How We Migrated Our iOS Project From SwiftPM to Tuist](https://engineering.backmarket.com/back-market-x-tuist-ii-how-we-migrated-our-ios-project-from-swiftpm-to-tuist-cef9ecc88c8c)
+- [Back Market x Tuist Part III: How We Enforce Our Modularization Strategy With Tuist](https://engineering.backmarket.com/back-market-x-tuist-part-iii-how-we-enforce-our-modularization-strategy-with-tuist-1c82fd5115a9)
 - [First touches of using Tuist for Xcode Project generation](https://medium.com/swlh/first-touches-of-using-tuist-for-xcode-project-generation-f46c630bc29b)
 - [Our Journey to Generated Projects](https://www.ackee.cz/blog/en/tuist-our-journey-to-generated-projects/)
 - [The Magic of Generating an Xcode Project](https://developers.soundcloud.com/blog/tuist-project-generation)


### PR DESCRIPTION
This PR adds three blog posts from Back Market Engineering about their journey with Tuist:

1. **Back Market x Tuist - Part I: Why We Moved Our iOS Project To Tuist**
   - https://engineering.backmarket.com/back-market-x-tuist-part-i-why-we-moved-our-ios-project-to-tuist-f161cf914700

2. **Back Market x Tuist II: How We Migrated Our iOS Project From SwiftPM to Tuist**
   - https://engineering.backmarket.com/back-market-x-tuist-ii-how-we-migrated-our-ios-project-from-swiftpm-to-tuist-cef9ecc88c8c

3. **Back Market x Tuist Part III: How We Enforce Our Modularization Strategy With Tuist**
   - https://engineering.backmarket.com/back-market-x-tuist-part-iii-how-we-enforce-our-modularization-strategy-with-tuist-1c82fd5115a9

These posts provide valuable insights into why and how Back Market adopted Tuist for their iOS project, including their migration from Swift Package Manager and how they enforce their modularization strategy.